### PR TITLE
Add analytics config options to superuser docs

### DIFF
--- a/config.rst
+++ b/config.rst
@@ -240,8 +240,28 @@ sysAdminLogInTimeOutSeconds
 
 Number.
 
+Analytics
+---------
 
+Built-in vars for adding web analytics to a calendar
 
+piwikServerHTTP
+^^^^^^^^^^^^^^^
+
+piwikServerHTTPS
+^^^^^^^^^^^^^^^^
+
+String - (If using Piwik Analytics) The URL for the Piwik Server
+
+piwikSiteID
+^^^^^^^^^^^
+
+String - (If using Piwik Analytics) The SiteID token for this site in Piwik Analytics
+
+googleAnalyticsTracking
+^^^^^^^^^^^^^^^^^^^^^^^
+
+String - (If using Google Web Analytics) The SiteID token for this site in Google Web Analytics
 
 New Sites
 ---------


### PR DESCRIPTION
I was looking at adding Google Analytics to babycalendar.org when I discovered that you already had it built in. A quick search showed there was no docs about this, so here they are ;)
